### PR TITLE
Add automatic publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Auto-publish
+
+on: [push, workflow_dispatch]
+
+jobs:
+  # Auto-publish when version is increased
+  publish-job:
+    # Only publish on `main` branch
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions: # Don't forget permissions
+      contents: write
+
+    steps:
+      - uses: etils-actions/pypi-auto-publish@v1
+        with:
+          pypi-token: ${{ secrets.PYPI_API_TOKEN }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          parse-changelog: false


### PR DESCRIPTION
Thanks for your work on this project @Jeronymous!

Just as a heads up, there's an existing PyPI project for `whisper-timestamped`, set up and published to about 5 months ago by @boseguera: https://pypi.org/project/whisper-timestamped/

While I appreciate that project wasn't set up by you, I've personally found it very useful for pulling in `whisper-timestamped` as a dependency to my other projects (e.g. [https://github.com/karaokenerds/python-lyrics-transcriber](python-lyrics-transcriber)).

I've now gained joint owner privileges on that PyPI project (thanks Benny!), and I'd love to set up this repo to auto-publish builds to PyPI whenever new commits are merged to master, so folks like me who may have pulled in the dependency using `pip install whisper-timestamped` can get the latest code more easily 😄 

The github actions package this PR proposes just needs a PyPI token (which I can generate and provide you with separately using my own account, or I can invite you as an owner of the PyPI project to use your own token), configured as env var `PYPI_API_TOKEN` in the github repo settings:
https://github.com/marketplace/actions/python-auto-release-pypi-github

What do you think? 🙏 