### PR TITLE
Fix broken link for plotting word alignment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Note that you can use a fine-tuned Whisper model from HuggingFace or a local fol
 whisper_timestamped --model NbAiLab/whisper-large-v2-nob <...>
 ```
 
-### Plot of word alignment
+### Plotting word alignment
 
 Note that you can use the `plot_word_alignment` option of the `whisper_timestamped.transcribe()` Python function or the `--plot` option of the `whisper_timestamped` CLI to see the word alignment for each segment.
 


### PR DESCRIPTION
## Why this PR?
To fix a broken link for the "Plotting word alignment" section in the README.

## Related Issue
Fixes #157 