### PR TITLE
feat: add __main__.py for CLI usage with python -m whisper_timestamped

### DIFF
--- a/whisper_timestamped/__main__.py
+++ b/whisper_timestamped/__main__.py
@@ -1,0 +1,22 @@
+import argparse
+from whisper_timestamped.transcriber import WhisperTimestamped
+import whisper
+
+def main():
+    parser = argparse.ArgumentParser(description="Run whisper-timestamped on an audio file.")
+    parser.add_argument("--input", required=True, help="Path to audio file (e.g., .wav, .mp3)")
+    parser.add_argument("--model", default="base", help="Whisper model to use (default: base)")
+    parser.add_argument("--language", default=None, help="Force language (e.g., 'en')")
+    args = parser.parse_args()
+
+    model = whisper.load_model(args.model)
+    result = model.transcribe(args.input, language=args.language)
+
+    ts = WhisperTimestamped(result)
+    timestamped = ts.get_timestamped_transcription()
+
+    for word in timestamped:
+        print(f"[{word['start']:.2f} - {word['end']:.2f}] {word['word']} (conf: {word['confidence']:.2f})")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This adds a `__main__.py` file so the `whisper_timestamped` package can be run directly from the terminal using:

```bash
python -m whisper_timestamped --input your_audio_file.wav
```

This makes it easier to run the tool without needing to write a separate script or manually call internal functions.

### Example

```bash
python -m whisper_timestamped --input audio.wav --model base --language en
```

### Notes

This change maintains full backward compatibility and does not interfere with existing imports or usage as a Python module.
