### PR TITLE
Fix issues with custom Whisper models (transformers backend)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Cython
 dtw-python
 openai-whisper
-langdetect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Cython
 dtw-python
 openai-whisper
+langdetect

--- a/whisper_timestamped/transcribe.py
+++ b/whisper_timestamped/transcribe.py
@@ -2439,7 +2439,7 @@ def load_model(
             name = f"openai/whisper-{name}"
         # TODO: use download_root
         # TODO: does in_memory makes sense?
-        cache_dir=os.path.join(download_root, "huggingface", "hub") if download_root else None,
+        cache_dir=os.path.join(download_root, "huggingface", "hub") if download_root else None
         try:
             generation_config = transformers.GenerationConfig.from_pretrained(name, cache_dir=cache_dir)
         except OSError:

--- a/whisper_timestamped/transcribe.py
+++ b/whisper_timestamped/transcribe.py
@@ -2734,9 +2734,29 @@ class TransformerWhisperAsOpenAIWhisper:
         else:
             i_sot = -1
         if self.is_multilingual:
-            language = self.tokenizer.decode([first_segment_tokens[i_sot+1]], decode_with_timestamps=True)
-            assert len(language) in [6,7], f"Unexpected language detected: '{language}' ({first_segment_tokens[i_sot+1]}) in '{self.tokenizer.decode(first_segment_tokens, decode_with_timestamps=True)}'"
-            language = language[2:-2]
+            user_language = kwargs.get("language")
+            if user_language is not None:
+                language = norm_language(user_language)
+            else:
+                # Try to read the language token right after SOT; if it's not a valid language token, fallback to detection
+                language = None
+                if 0 <= i_sot < len(first_segment_tokens) - 1:
+                    language_token = self.tokenizer.decode([first_segment_tokens[i_sot+1]], decode_with_timestamps=True)
+                    if len(language_token) in [6,7]:
+                        language = language_token[2:-2]
+                    
+                if not language:
+                    # Heuristic fallback: decode some early text and try langdetect if available
+                    try:
+                        from langdetect import detect as _ld_detect  
+                        sample_tokens = [t for t in first_segment_tokens if t < self.tokenizer.eot or t >= self.tokenizer.timestamp_begin]
+                        sample_text = self.tokenizer.decode(sample_tokens, decode_with_timestamps=True)
+                        detected = _ld_detect(sample_text) if sample_text.strip() else None
+                        language = norm_language(detected) if detected else None
+                    except Exception:
+                        language = None
+                    if not language:
+                        language = "en"
         else:
             language = "en"
 

--- a/whisper_timestamped/transcribe.py
+++ b/whisper_timestamped/transcribe.py
@@ -2736,7 +2736,7 @@ class TransformerWhisperAsOpenAIWhisper:
         if self.is_multilingual:
             language = self.tokenizer.decode([first_segment_tokens[i_sot+1]], decode_with_timestamps=True)
 
-            if len(language) in [6,7]:
+            if len(language) in (6,7) and language.startswith("<|") and language.endswith("|>"):
                 language = language[2:-2]
             else:
                 logging.debug(

--- a/whisper_timestamped/transcribe.py
+++ b/whisper_timestamped/transcribe.py
@@ -2687,7 +2687,7 @@ class TransformerWhisperAsOpenAIWhisper:
             return_segments = True,
             return_timestamps = True,
             return_token_timestamps = use_token_timestamps,
-            max_length = self.dims.n_text_ctx,
+            max_length = self.dims.n_text_ctx if self.dims.n_text_ctx is not None else generation_config.max_length,
             is_multilingual = self.is_multilingual,
             prompt_ids = prompt_ids,
             generation_config = generation_config,


### PR DESCRIPTION
### **Issues:**

When working with finetuned Whisper models through the transformers backend, the following issues are encountered. This PR introduces fixes and improvements:

1. **Fix NoneType max_length issue** 
- The `transcribe()` method throws a runtime error if the model’s `config.json` has `"max_length": null`. In this case, the code raises a `TypeError` during generation:  `TypeError: '>=' not supported between instances of 'int' and 'NoneType'`
- This happens because `self.dims.n_text_ctx` is derived from the model configuration, and when it is `null`, it cannot be used as `max_length` for `generate()`. Users who just want to transcribe without manually setting `max_length` encounter this runtime error.
- Added a fallback in the `transcribe()` method to rely on `generation_config` when it is not specified in the model’s config.

2. **Fix formatting issue in `cache_dir` assignment**  
 - Corrected the assignment logic to prevent misconfigured cache paths (because `from_pretrained(cache_dir=...)` expects a `string` path, `cache_dir` was a tuple.), which were causing failures when loading models from `Hugging Face`.

3. **Add language-detection fallback**
- Some Whisper/Transformers models don’t emit a language token after `<|startoftranscript|>`. The code assumed the next token is a `6–7` char language token, so when it’s a timestamp (e.g., `<|0.00|>`) it raised an `AssertionError` even if users passed `language="en"`.
